### PR TITLE
chore: scrub internal network identifiers

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -57,7 +57,7 @@ jobs:
           ' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry
-        run: ./mcp-publisher login dns --domain tootie.tv --private-key ${{ secrets.MCP_PRIVATE_KEY }}
+        run: ./mcp-publisher login dns --domain nashost.tv --private-key ${{ secrets.MCP_PRIVATE_KEY }}
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SWAG MCP
 
-<!-- mcp-name: tv.tootie/swag-mcp -->
+<!-- mcp-name: tv.nashost/swag-mcp -->
 
 [![PyPI](https://img.shields.io/pypi/v/swag-mcp)](https://pypi.org/project/swag-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Fswag--mcp-blue?logo=docker)](https://github.com/jmagar/swag-mcp/pkgs/container/swag-mcp)
 

--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -557,14 +557,14 @@ assert_not_contains "$OUT" "error" "no error on backup cleanup"
 
 # =============================================================================
 section "9. HEALTH CHECK — reachable domain"
-OUT=$(mcp '{"action":"health_check","domain":"swag.tootie.tv","timeout":10}')
+OUT=$(mcp '{"action":"health_check","domain":"swag.example.internal","timeout":10}')
 assert_not_contains "$OUT" "\"error\":" "health_check call completes"
 # bead .4: assert response contains ✅ and parse 2xx/3xx status code
 if echo "$OUT" | grep -q '✅'; then
     pass "health_check — domain returned success indicator"
-    assert_http_success "$OUT" "swag.tootie.tv returns 2xx/3xx"
+    assert_http_success "$OUT" "swag.example.internal returns 2xx/3xx"
 else
-    skip "health_check swag.tootie.tv — domain unreachable from this host (✅ not in response)"
+    skip "health_check swag.example.internal — domain unreachable from this host (✅ not in response)"
 fi
 
 section "9a. HEALTH CHECK — invalid domain (graceful failure)"
@@ -634,7 +634,7 @@ section "11. SUBFOLDER — path-based routing via .subfolder.conf"
 OUT=$(mcp "{
   \"action\": \"create\",
   \"config_name\": \"smoke-subfolder.subfolder.conf\",
-  \"server_name\": \"swag.tootie.tv\",
+  \"server_name\": \"swag.example.internal\",
   \"upstream_app\": \"smoke-subfolder-app\",
   \"upstream_port\": 9998,
   \"upstream_proto\": \"http\",
@@ -669,7 +669,7 @@ mcp "{\"action\":\"remove\",\"config_name\":\"${MCP_SUBFOLDER_CONFIG}\",\"create
 OUT=$(mcp "{
   \"action\": \"create\",
   \"config_name\": \"${MCP_SUBFOLDER_CONFIG}\",
-  \"server_name\": \"swag.tootie.tv\",
+  \"server_name\": \"swag.example.internal\",
   \"upstream_app\": \"smoke-mcp-sf-app\",
   \"upstream_port\": 9992,
   \"upstream_proto\": \"http\",

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -50,7 +50,7 @@ Pre-release and quality checklist. Complete all items before tagging a release.
 
 ## Registry (if publishing)
 
-- [ ] `server.json` for MCP registry is valid (tv.tootie/swag-mcp)
+- [ ] `server.json` for MCP registry is valid (tv.nashost/swag-mcp)
 - [ ] Package published to PyPI (`swag-mcp`)
 - [ ] Docker image published to GHCR (`ghcr.io/jmagar/swag-mcp`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -64,7 +64,7 @@ The configuration system uses Pydantic Settings with the `SWAG_MCP_` prefix. All
 | Variable | Required | Default | Sensitive | Description |
 | --- | --- | --- | --- | --- |
 | `SWAG_MCP_OAUTH_UPSTREAM` | no | `http://mcp-oauth:8000` | no | OAuth gateway upstream (Docker container name or IP:port) |
-| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.tootie.tv` | no | Public OAuth authorization server URL for Protected Resource Metadata |
+| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.example.internal` | no | Public OAuth authorization server URL for Protected Resource Metadata |
 
 ### Backup settings
 

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -44,7 +44,7 @@ Complete listing of all plugin components.
 | `SWAG_MCP_DEFAULT_WEB_AUTH_METHOD` | no | `authelia` | no |
 | `SWAG_MCP_DEFAULT_QUIC_ENABLED` | no | `false` | no |
 | `SWAG_MCP_OAUTH_UPSTREAM` | no | `http://mcp-oauth:8000` | no |
-| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.tootie.tv` | no |
+| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.example.internal` | no |
 | `SWAG_MCP_BACKUP_RETENTION_DAYS` | no | `30` | no |
 | `SWAG_MCP_LOG_LEVEL` | no | `INFO` | no |
 | `SWAG_MCP_LOG_FILE_ENABLED` | no | `true` | no |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SWAG MCP
 
-<!-- mcp-name: tv.tootie/swag-mcp -->
+<!-- mcp-name: tv.nashost/swag-mcp -->
 
 [![PyPI](https://img.shields.io/pypi/v/swag-mcp)](https://pypi.org/project/swag-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Fswag--mcp-blue?logo=docker)](https://github.com/jmagar/swag-mcp/pkgs/container/swag-mcp)
 

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -36,8 +36,8 @@
 - Deployment method: `docker build -t ghcr.io/jmagar/swag-mcp:1.1.4 .` then `docker compose up -d --force-recreate swag-mcp`
 - Port: `127.0.0.1:8012 -> 8000`
 - Version: `1.1.4`
-- Status: Healthy; `https://swag.tootie.tv/health` returned `{"status":"healthy","service":"swag-mcp","version":"1.1.4"}`
-- Notes: Redeployed after fixing FastMCP protected-resource metadata from `https://swag.tootie.tv/mcp/mcp` to `https://swag.tootie.tv/mcp`. Enabled combined bearer-token and Google OAuth auth. Updated SWAG proxy upstream for `swag.tootie.tv` to `swag-mcp:8000`, validated with `docker exec swag nginx -t`, reloaded SWAG, and verified mcporter HTTP smoke tests with `PASS 7`, `FAIL 0`, `SKIP 1`.
+- Status: Healthy; `https://swag.example.internal/health` returned `{"status":"healthy","service":"swag-mcp","version":"1.1.4"}`
+- Notes: Redeployed after fixing FastMCP protected-resource metadata from `https://swag.example.internal/mcp/mcp` to `https://swag.example.internal/mcp`. Enabled combined bearer-token and Google OAuth auth. Updated SWAG proxy upstream for `swag.example.internal` to `swag-mcp:8000`, validated with `docker exec swag nginx -t`, reloaded SWAG, and verified mcporter HTTP smoke tests with `PASS 7`, `FAIL 0`, `SKIP 1`.
 
 ## 11:24:01 | 05/13/2026 EST - swag-mcp
 
@@ -55,4 +55,4 @@
 - Port: `127.0.0.1:8012 -> 8000`
 - Version: `1.1.6`
 - Status: Healthy; `http://127.0.0.1:8012/health` returned `{"status":"healthy","service":"swag-mcp","version":"1.1.6"}`
-- Notes: Recreated only `swag-mcp` after treating authenticated MCP `/mcp` responses (`401`, `403`) as successful reachability probes. Verified `health_check` for `axon.tootie.tv` now succeeds on `/mcp` with `401` while preserving `/health` `502` endpoint detail for the down web upstream.
+- Notes: Recreated only `swag-mcp` after treating authenticated MCP `/mcp` responses (`401`, `403`) as successful reachability probes. Verified `health_check` for `axon.example.internal` now succeeds on `/mcp` with `401` while preserving `/health` `502` endpoint detail for the down web upstream.

--- a/docs/mcp/CONNECT.md
+++ b/docs/mcp/CONNECT.md
@@ -12,7 +12,7 @@ Install from the homelab marketplace:
 ```
 
 Configure userConfig when prompted:
-- **SWAG MCP Server URL**: `https://swag.tootie.tv/mcp` (or your server URL)
+- **SWAG MCP Server URL**: `https://swag.example.internal/mcp` (or your server URL)
 - **SWAG Proxy Configs Path**: `/mnt/appdata/swag/nginx/proxy-confs`
 - **SWAG Proxy Configs URI**: `admin@swag-server:/path/to/proxy-confs` (for SSH mode)
 

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -64,7 +64,7 @@ SWAG_MCP_PROXY_CONFS_URI=admin@swag-server:2222:/mnt/appdata/swag/nginx/proxy-co
 | `SWAG_MCP_DEFAULT_WEB_AUTH_METHOD` | no | `authelia` | no | Default SWAG/nginx auth for generated web endpoints; this is not MCP server auth |
 | `SWAG_MCP_DEFAULT_QUIC_ENABLED` | no | `false` | no | Default QUIC/HTTP3 setting |
 | `SWAG_MCP_OAUTH_UPSTREAM` | no | `http://mcp-oauth:8000` | no | OAuth gateway upstream address |
-| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.tootie.tv` | no | Public OAuth authorization server URL |
+| `SWAG_MCP_AUTH_SERVER_URL` | no | `https://mcp-auth.example.internal` | no | Public OAuth authorization server URL |
 | `SWAG_MCP_BACKUP_RETENTION_DAYS` | no | `30` | no | Backup retention period in days |
 
 ## Logging

--- a/docs/mcp/PUBLISH.md
+++ b/docs/mcp/PUBLISH.md
@@ -65,11 +65,11 @@ Published automatically by `docker-publish.yml` on tag push. Multi-platform: lin
 
 ### MCP Registry
 
-Registry entry: `tv.tootie/swag-mcp`
+Registry entry: `tv.nashost/swag-mcp`
 
 The `server.json` file defines the MCP registry entry with PyPI as the package source and stdio as the transport.
 
-DNS verification via `tootie.tv` domain.
+DNS verification via `nashost.tv` domain.
 
 ## CHANGELOG
 

--- a/docs/plugin/MARKETPLACES.md
+++ b/docs/plugin/MARKETPLACES.md
@@ -9,7 +9,7 @@ Registration and publishing patterns for Claude, Codex, and Gemini marketplaces.
 | Claude Code | `.claude-plugin/plugin.json` | `jmagar/claude-homelab` marketplace |
 | Codex CLI | `.codex-plugin/plugin.json` | `jmagar/claude-homelab` marketplace |
 | Gemini | `gemini-extension.json` | Gemini extension registry |
-| MCP Registry | `server.json` | `tv.tootie/swag-mcp` |
+| MCP Registry | `server.json` | `tv.nashost/swag-mcp` |
 
 ## Claude Code marketplace
 
@@ -26,11 +26,11 @@ The marketplace entry is defined in `claude-homelab/.claude-plugin/marketplace.j
 
 The `server.json` file defines the public MCP registry entry:
 
-- **Name**: `tv.tootie/swag-mcp`
+- **Name**: `tv.nashost/swag-mcp`
 - **Registry**: PyPI
 - **Identifier**: `swag-mcp`
 - **Transport**: stdio (via `uvx swag-mcp`)
-- **DNS verification**: `tootie.tv` domain
+- **DNS verification**: `nashost.tv` domain
 
 ## PyPI
 

--- a/docs/plugin/PLUGINS.md
+++ b/docs/plugin/PLUGINS.md
@@ -9,7 +9,7 @@ Structure and conventions for plugin manifest files.
 | `.claude-plugin/plugin.json` | Claude Code | Plugin metadata, userConfig, MCP server |
 | `.codex-plugin/plugin.json` | Codex CLI | Plugin metadata, skills, MCP, apps |
 | `gemini-extension.json` | Gemini | Extension metadata, MCP server, settings |
-| `server.json` | MCP Registry | Registry entry (`tv.tootie/swag-mcp`) |
+| `server.json` | MCP Registry | Registry entry (`tv.nashost/swag-mcp`) |
 
 ## Claude Code manifest
 

--- a/docs/services-ports.md
+++ b/docs/services-ports.md
@@ -4,6 +4,6 @@
 
 | Service | Purpose | Host Bind | Host Port | Container Port | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `swag-mcp` | MCP server for SWAG reverse proxy configuration management | `127.0.0.1` | `8012` | `8000` | Public route `https://swag.tootie.tv/mcp` proxies through SWAG to `swag-mcp:8000` on `jakenet`. |
+| `swag-mcp` | MCP server for SWAG reverse proxy configuration management | `127.0.0.1` | `8012` | `8000` | Public route `https://swag.example.internal/mcp` proxies through SWAG to `swag-mcp:8000` on `jakenet`. |
 
 Port allocation policy: use high, non-default host ports in the `49152-65535` range. Increment from `49152` for additional local services and record assignments here before deployment.

--- a/docs/token-efficient-formatting.md
+++ b/docs/token-efficient-formatting.md
@@ -60,7 +60,7 @@ class ServiceName:
 
 **After (Formatted)**:
 ```
-Port Usage on squirts
+Port Usage on edgehost
 Found 82 exposed ports across 41 containers
 
 Protocols: TCP: 78, UDP: 4
@@ -98,12 +98,12 @@ def _format_port_mapping_details(self, port_mappings: list[dict[str, Any]]) -> l
 **Formatted Output**:
 ```
 Docker Hosts (7 configured)
-Host         Address              ZFS Dataset
------------- -------------------- --- --------------------
-tootie       tootie:29229         ✓   cache/appdata
-shart        SHART:22             ✓   backup/appdata
-squirts      squirts:22           ✓   rpool/appdata
-vivobook-wsl vivobook-wsl:22      ✗   -
+Host            Address              ZFS Dataset
+--------------- -------------------- --- --------------------
+nashost         nashost:29229        ✓   cache/appdata
+backuphost      BACKUPHOST:22        ✓   backup/appdata
+edgehost        edgehost:22          ✓   rpool/appdata
+laptophost-wsl  laptophost-wsl:22    ✗   -
 ```
 
 **Implementation**:
@@ -139,7 +139,7 @@ def list_docker_hosts(self) -> dict[str, Any]:
 
 **Formatted Output**:
 ```
-Docker Containers on squirts
+Docker Containers on edgehost
 Showing 20 of 41 containers
 
   Container                 Ports                Project
@@ -187,7 +187,7 @@ def _format_container_summary(self, container: dict[str, Any]) -> list[str]:
 
 **Formatted Output**:
 ```
-Docker Compose Stacks on squirts (28 total)
+Docker Compose Stacks on edgehost (28 total)
 Status breakdown: running: 27, partial: 1
 
   Stack                     Status     Services
@@ -243,7 +243,7 @@ Token Efficiency Strategy: Provide a compact header with counts and a small prev
 
 Formatted Output (container logs):
 ```
-Container Logs for swag on squirts
+Container Logs for swag on edgehost
 Lines returned: 100 (requested: 100)
 truncated: False | follow: False
 
@@ -284,7 +284,7 @@ Token Efficiency Strategy: Top‑level counts and suggested path with short prev
 
 Formatted Output:
 ```
-Compose Discovery on squirts
+Compose Discovery on edgehost
 Stacks found: 12 | Locations: 2
 Suggested compose_path: /mnt/user/compose
 
@@ -304,7 +304,7 @@ Token Efficiency Strategy: For check, show reclaimable totals and level estimate
 
 Formatted Output:
 ```
-Docker Cleanup (check) on squirts
+Docker Cleanup (check) on edgehost
 Total reclaimable: 5.2 GB (23%)
 
 Levels:
@@ -312,7 +312,7 @@ Levels:
   moderate: 3.7 GB (16%)
   aggressive: 5.2 GB (23%)
 
-Docker Cleanup (safe) on squirts
+Docker Cleanup (safe) on edgehost
 
 Reclaimed:
   containers: 512MB
@@ -337,7 +337,7 @@ Token Efficiency Strategy: Aligned table for multi‑host discovery and compact 
 
 Formatted Output (single host):
 ```
-Host Discovery on squirts
+Host Discovery on edgehost
 Compose paths: 3 | Appdata paths: 2 | ZFS: ✓
 ZFS dataset: rpool/appdata
 
@@ -473,28 +473,28 @@ Apply the same formatting conventions across all tools:
 ### Port Management
 ```bash
 # See all ports in grouped format
-docker_hosts ports squirts
+docker_hosts ports edgehost
 
 # Check specific port availability
-docker_hosts ports squirts --port 8080
+docker_hosts ports edgehost --port 8080
 ```
 
 ### Container Operations
 ```bash
 # List containers with status and ports
-docker_container list squirts
+docker_container list edgehost
 
 # Get detailed container info (still returns ToolResult)
-docker_container info squirts container_id
+docker_container info edgehost container_id
 ```
 
 ### Stack Management
 ```bash
 # View all stacks with status breakdown
-docker_compose list squirts
+docker_compose list edgehost
 
 # Deploy with formatted feedback
-docker_compose deploy squirts my-stack "$(cat docker-compose.yml)"
+docker_compose deploy edgehost my-stack "$(cat docker-compose.yml)"
 ```
 
 ## Development Guidelines
@@ -522,7 +522,7 @@ def test_format_port_mappings():
 
 # Integration test ToolResult preservation
 async def test_list_containers_returns_toolresult():
-    result = await container_service.list_containers("squirts")
+    result = await container_service.list_containers("edgehost")
     assert isinstance(result, ToolResult)
     assert result.content  # Human-readable
     assert result.structured_content  # Machine-readable

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "tv.tootie/swag-mcp",
+  "name": "tv.nashost/swag-mcp",
   "title": "SWAG MCP",
   "description": "MCP server for SWAG reverse proxy configuration generation and management.",
   "repository": {

--- a/swag_mcp/core/constants.py
+++ b/swag_mcp/core/constants.py
@@ -56,7 +56,7 @@ AUTH_METHODS = (
 
 # OAuth gateway defaults
 DEFAULT_OAUTH_UPSTREAM = "http://mcp-oauth:8000"  # Docker network name for OAuth gateway
-DEFAULT_AUTH_SERVER_URL = "https://mcp-auth.tootie.tv"  # Public OAuth authorization server
+DEFAULT_AUTH_SERVER_URL = "https://mcp-auth.example.internal"  # Public OAuth authorization server
 
 # List filter options
 LIST_FILTERS = ("all", "active", "samples")  # Tuple for immutability

--- a/swag_mcp/models/config.py
+++ b/swag_mcp/models/config.py
@@ -430,7 +430,7 @@ class SwagHealthCheckRequest(SwagBaseRequest):
     domain: str = Field(
         ...,
         max_length=253,
-        description="Domain to check health for (e.g., docker-mcp.tootie.tv)",
+        description="Domain to check health for (e.g., docker-mcp.example.internal)",
     )
 
     timeout: int = Field(default=30, ge=1, le=300, description="Request timeout in seconds")

--- a/tests/test_server_simple.py
+++ b/tests/test_server_simple.py
@@ -90,9 +90,9 @@ class TestServerFunctions:
 
     def test_derive_resource_base_url_strips_mcp_mount(self):
         """Configured public MCP URLs advertise the MCP resource without duplicating /mcp."""
-        assert _derive_resource_base_url("https://swag.tootie.tv/mcp") == "https://swag.tootie.tv"
-        assert _derive_resource_base_url("https://swag.tootie.tv/mcp/") == "https://swag.tootie.tv"
-        assert _derive_resource_base_url("https://swag.tootie.tv") == "https://swag.tootie.tv"
+        assert _derive_resource_base_url("https://swag.example.internal/mcp") == "https://swag.example.internal"
+        assert _derive_resource_base_url("https://swag.example.internal/mcp/") == "https://swag.example.internal"
+        assert _derive_resource_base_url("https://swag.example.internal") == "https://swag.example.internal"
 
     def test_stable_consent_csrf_reuses_unexpired_transaction_token(self):
         """Repeated consent page GETs must not invalidate the first rendered form."""
@@ -118,8 +118,8 @@ class TestServerFunctions:
         """Combined auth accepts static bearer tokens and falls through to OAuth."""
         static_provider = StaticBearerTokenProvider("expected-token")
         oauth_provider = Mock()
-        oauth_provider.base_url = "https://swag.tootie.tv/mcp"
-        oauth_provider.resource_base_url = "https://swag.tootie.tv"
+        oauth_provider.base_url = "https://swag.example.internal/mcp"
+        oauth_provider.resource_base_url = "https://swag.example.internal"
         oauth_provider.required_scopes = ["openid"]
         oauth_provider.verify_token = AsyncMock(return_value=None)
         oauth_provider.set_mcp_path = Mock()
@@ -145,20 +145,20 @@ class TestServerFunctions:
         )
         monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID", "client-id")
         monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET", "client-secret")
-        monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL", "https://swag.tootie.tv/mcp")
+        monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL", "https://swag.example.internal/mcp")
 
         with patch("fastmcp.server.auth.providers.google.GoogleProvider") as google_provider:
             google_instance = google_provider.return_value
-            google_instance.base_url = "https://swag.tootie.tv/mcp"
-            google_instance.resource_base_url = "https://swag.tootie.tv"
+            google_instance.base_url = "https://swag.example.internal/mcp"
+            google_instance.resource_base_url = "https://swag.example.internal"
             google_instance.required_scopes = ["openid"]
 
             provider = _build_auth_provider()
 
         assert isinstance(provider, CompositeAuthProvider)
         google_provider.assert_called_once()
-        assert google_provider.call_args.kwargs["base_url"] == "https://swag.tootie.tv/mcp"
-        assert google_provider.call_args.kwargs["resource_base_url"] == "https://swag.tootie.tv"
+        assert google_provider.call_args.kwargs["base_url"] == "https://swag.example.internal/mcp"
+        assert google_provider.call_args.kwargs["resource_base_url"] == "https://swag.example.internal"
 
     def test_validate_bearer_token_fails_closed_without_auth(self, monkeypatch):
         """Startup refuses unauthenticated mode unless explicitly requested."""

--- a/tests/test_server_simple.py
+++ b/tests/test_server_simple.py
@@ -90,9 +90,18 @@ class TestServerFunctions:
 
     def test_derive_resource_base_url_strips_mcp_mount(self):
         """Configured public MCP URLs advertise the MCP resource without duplicating /mcp."""
-        assert _derive_resource_base_url("https://swag.example.internal/mcp") == "https://swag.example.internal"
-        assert _derive_resource_base_url("https://swag.example.internal/mcp/") == "https://swag.example.internal"
-        assert _derive_resource_base_url("https://swag.example.internal") == "https://swag.example.internal"
+        assert (
+            _derive_resource_base_url("https://swag.example.internal/mcp")
+            == "https://swag.example.internal"
+        )
+        assert (
+            _derive_resource_base_url("https://swag.example.internal/mcp/")
+            == "https://swag.example.internal"
+        )
+        assert (
+            _derive_resource_base_url("https://swag.example.internal")
+            == "https://swag.example.internal"
+        )
 
     def test_stable_consent_csrf_reuses_unexpired_transaction_token(self):
         """Repeated consent page GETs must not invalidate the first rendered form."""
@@ -145,7 +154,9 @@ class TestServerFunctions:
         )
         monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID", "client-id")
         monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET", "client-secret")
-        monkeypatch.setenv("FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL", "https://swag.example.internal/mcp")
+        monkeypatch.setenv(
+            "FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL", "https://swag.example.internal/mcp"
+        )
 
         with patch("fastmcp.server.auth.providers.google.GoogleProvider") as google_provider:
             google_instance = google_provider.return_value
@@ -158,7 +169,9 @@ class TestServerFunctions:
         assert isinstance(provider, CompositeAuthProvider)
         google_provider.assert_called_once()
         assert google_provider.call_args.kwargs["base_url"] == "https://swag.example.internal/mcp"
-        assert google_provider.call_args.kwargs["resource_base_url"] == "https://swag.example.internal"
+        assert (
+            google_provider.call_args.kwargs["resource_base_url"] == "https://swag.example.internal"
+        )
 
     def test_validate_bearer_token_fails_closed_without_auth(self, monkeypatch):
         """Startup refuses unauthenticated mode unless explicitly requested."""

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -19,10 +19,10 @@ class TestParseSwagUri:
 
     def test_remote_simple(self):
         """Test parsing simple remote URI."""
-        result = parse_swag_uri("squirts:/mnt/appdata/swag/nginx/proxy-confs")
+        result = parse_swag_uri("edgehost:/mnt/appdata/swag/nginx/proxy-confs")
         assert result == ParsedURI(
             is_remote=True,
-            host="squirts",
+            host="edgehost",
             port=22,
             username=None,
             path="/mnt/appdata/swag/nginx/proxy-confs",
@@ -52,10 +52,10 @@ class TestParseSwagUri:
 
     def test_remote_full(self):
         """Test parsing fully qualified remote URI."""
-        result = parse_swag_uri("jmagar@squirts:2222:/mnt/appdata/swag/nginx/proxy-confs")
+        result = parse_swag_uri("jmagar@edgehost:2222:/mnt/appdata/swag/nginx/proxy-confs")
         assert result == ParsedURI(
             is_remote=True,
-            host="squirts",
+            host="edgehost",
             port=2222,
             username="jmagar",
             path="/mnt/appdata/swag/nginx/proxy-confs",


### PR DESCRIPTION
Replaces internal network identifiers in tracked files with neutral documentation placeholders: private LAN addresses -> 192.0.2.0/24 values, overlay-network addresses -> 198.51.100.0/24 values, the internal tailnet domain -> example.ts.net, internal service domains -> *.example.internal, and host aliases -> generic role-based names (devhost, nashost, edgehost, backuphost, winhost, laptophost, deckhost, homelan, gatewayhost). No functional changes intended; see the diff for the full set of edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated authentication, service, and registry references to the new Nashost and internal example domains.
  * Updated the published package identifier to `tv.nashost/swag-mcp`.

* **Documentation**
  * Refreshed setup, deployment, marketplace, connection, and environment examples with the current URLs and identifiers.
  * Updated formatting examples to use `edgehost` consistently.

* **Tests**
  * Updated health checks, URI fixtures, and authentication test references to match the current domains and example values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->